### PR TITLE
chore: update build.gradle for Android API 33

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,10 +26,10 @@ rootProject.allprojects {
 }
 
 android {
-    compileSdkVersion safeExtGet('Picky_compileSdkVersion', 29)
+    compileSdkVersion safeExtGet('Picky_compileSdkVersion', 33)
     defaultConfig {
-        minSdkVersion safeExtGet('Picky_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('Picky_targetSdkVersion', 29)
+        minSdkVersion safeExtGet('Picky_minSdkVersion', 21)
+        targetSdkVersion safeExtGet('Picky_targetSdkVersion', 33)
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
### Description

This PR updates the `compileSdkVersion`, `minSdkVersion`, and `targetSdkVersion` in the android configuration for react-native-picky. The purpose of this update is to ensure compatibility with newer versions of Android and React Native projects that use a `compileSdkVersion` of higher than 29.

The motivation for this PR was to prevent build errors when utilizing a higher SDK version, noticing that two recent forks of this library already exist making a similar change, and thinking they should be folded in to the library itself. 

### Changes to build.gradle
- Updated `compileSdkVersion` from `29` to `33`
- Updated `minSdkVersion` from `16` to `21`
- Updated `targetSdkVersion` from `29` to `33`

### Impact

With these changes, projects using a higher `compileSdkVersion` can avoid build failures when including `react-native-picky`. Note that this update also increases the `minSdkVersion` to `21`, which means projects that need to support Android devices below this version may not be able to use `react-native-picky` with these updates.

### Testing 

Before submitting this PR, I've built an app using the forked `react-native-picky` library, and confirmed that the app builds successfully on both local environment and on EAS. 

Thanks for a creating a great library. I hope you'll consider this PR, and let me know if there are any questions or additional steps needed. 
